### PR TITLE
rain test

### DIFF
--- a/rainfall.red
+++ b/rainfall.red
@@ -1,0 +1,40 @@
+Red []
+
+#include %animate.red
+
+~size: system/view/screens/1/size * 6x7 / 10
+~scale: ~size * 10 / 1000x1000
+; drop: draw 10x20 [shape [move 5x0 'line -5x20 'arc 10x0 6 10 0 large close]]
+drop: [shape [move 5x0 line 0x20 arc 10x20 6 10 0 large close]]
+layers: 5
+drops: collect [repeat i layers [
+	i: i + 1
+	keep/only compose/only [scale (1 / i) (1 / i) (drop)]
+]]
+data: collect [repeat i layers [
+	keep b: to [] object compose/deep/only [
+		number: 30 * i
+		emitter: [0x0 (~size * 1x-1)]
+		speed: 400 / (i + 1)
+		direction: 85 + random 10
+		shapes: reduce [(drops/:i)]
+		limits: [y > (~size/y * (1 / i + 2) / 3)]
+		new-coords: [x: random ~size/x y: 0]
+		; new-coords: [p: random (~size * 1x0) x: p/x y: p/y]
+	]
+	set to word! rejoin ['data i] b 
+]]
+view compose/deep/only [
+	base ~size white rate 66 on-create [
+		animate [
+			start 0 duration 60 ease :ease-in-expo
+				; [box 10x10 from 10x70 to 70x70]
+				; image from 0x0 to 100x0 drop
+				(collect [repeat i layers [keep reduce [
+					'particles to word! rejoin ['value-with-zero-value i] to word! rejoin ['data i]
+					; 'on-exit [print "111"]
+				]]])
+		] face
+	]
+]
+quit


### PR DESCRIPTION
My play with particle effects take one. Hopefully it will serve as a basis for more flexible effects implementation.
<img src=https://i.gyazo.com/47ab4f11ebdd0c17cb80bdba9f5ec9e2.png width=400></img>

What I wanted is to make drops "splash" when they hit the ground. 
1. 1st obstacle was the ground itself: since `limits` do not account for particle itself (it's scale or type or anything), I had to declare multiple layers of particles, each with it's own ground floor. I also couldn't tune speed, number of particles of each type, direction based on particle size, all leading me to layers.
2. 2nd was that I could not place an actor on particles respawn point. `on-exit` fires once the effect finishes after a minute.
3. 3rd - even if I had the actor, how would I `morph` the particle itself? I wanted to morph it into two concentric ellipses first, then morph those two into bigger 2 (inner ellipse bright, outer already transparent), then again into even bigger 2, but both transparent now, so they would both extend and fade out.
